### PR TITLE
Add Mythic Beasts provider config

### DIFF
--- a/.github/workflows/octodns-deploy.yml
+++ b/.github/workflows/octodns-deploy.yml
@@ -127,6 +127,7 @@ jobs:
         uses: solvaholic/octodns-sync@main
         with:
           config_path: ${{ needs.meta.outputs.config }}
+          octodns_ref: master
           doit: --doit
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.route53_aws_key_id }}

--- a/.github/workflows/octodns-deploy.yml
+++ b/.github/workflows/octodns-deploy.yml
@@ -127,8 +127,8 @@ jobs:
         uses: solvaholic/octodns-sync@main
         with:
           config_path: ${{ needs.meta.outputs.config }}
-          octodns_ref: master
           doit: --doit
+          octodns_ref: master
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.route53_aws_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.route53_aws_secret_access_key }}

--- a/.github/workflows/octodns-deploy.yml
+++ b/.github/workflows/octodns-deploy.yml
@@ -131,6 +131,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.route53_aws_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.route53_aws_secret_access_key }}
-          MYTHIC_BEASTS_SECRET: ${{ secrets.mythic_beasts_secret }}
+          MYTHIC_BEASTS_PASSWORD: ${{ secrets.mythic_beasts_password }}
       # name: Test ${{ needs.meta.outputs.config }} deployment
         # TODO: Run octodns-sync to confirm no changes to be made?

--- a/.github/workflows/octodns-deploy.yml
+++ b/.github/workflows/octodns-deploy.yml
@@ -131,5 +131,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.route53_aws_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.route53_aws_secret_access_key }}
+          MYTHIC_BEASTS_SECRET: ${{ secrets.mythic_beasts_secret }}
       # name: Test ${{ needs.meta.outputs.config }} deployment
         # TODO: Run octodns-sync to confirm no changes to be made?

--- a/.github/workflows/octodns-validate.yml
+++ b/.github/workflows/octodns-validate.yml
@@ -100,6 +100,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.route53_aws_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.route53_aws_secret_access_key }}
+          MYTHIC_BEASTS_SECRET: ${{ secrets.mythic_beasts_secret }}
 
   comment:
     name: Add ${{ needs.meta.outputs.config }} plan to PR comment

--- a/.github/workflows/octodns-validate.yml
+++ b/.github/workflows/octodns-validate.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.route53_aws_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.route53_aws_secret_access_key }}
-          MYTHIC_BEASTS_SECRET: ${{ secrets.mythic_beasts_secret }}
+          MYTHIC_BEASTS_PASSWORD: ${{ secrets.mythic_beasts_password }}
 
   comment:
     name: Add ${{ needs.meta.outputs.config }} plan to PR comment

--- a/.github/workflows/octodns-validate.yml
+++ b/.github/workflows/octodns-validate.yml
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Find previous comment, if present
-        uses: peter-evans/find-comment@v1.2.0
+        uses: peter-evans/find-comment@v1.3.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/octodns-validate.yml
+++ b/.github/workflows/octodns-validate.yml
@@ -97,6 +97,7 @@ jobs:
         # TODO: When no changes, skip the rest of this workflow?
         with:
           config_path: ${{ needs.meta.outputs.config }}
+          octodns_ref: master
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.route53_aws_key_id }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.route53_aws_secret_access_key }}

--- a/public.yaml
+++ b/public.yaml
@@ -11,7 +11,7 @@ providers:
   mythicbeasts:
     class: octodns.provider.mythicbeasts.MythicBeastsProvider
     passwords:
-      solvahol.org.: env/MYTHIC_BEASTS_SECRET
+      solvahol.org.: env/MYTHIC_BEASTS_PASSWORD
   route53:
     class: octodns.provider.route53.Route53Provider
     access_key_id: env/AWS_ACCESS_KEY_ID

--- a/public.yaml
+++ b/public.yaml
@@ -10,8 +10,8 @@ providers:
     directory: .
   mythicbeasts:
     class: octodns.provider.mythicbeasts.MythicBeastsProvider
-      passwords:
-        solvahol.org.: env/MYTHIC_BEASTS_SECRET
+    passwords:
+      solvahol.org.: env/MYTHIC_BEASTS_SECRET
   route53:
     class: octodns.provider.route53.Route53Provider
     access_key_id: env/AWS_ACCESS_KEY_ID

--- a/public.yaml
+++ b/public.yaml
@@ -8,6 +8,10 @@ providers:
   config:
     class: octodns.provider.yaml.YamlProvider
     directory: .
+  mythicbeasts:
+    class: octodns.provider.mythicbeasts.MythicBeastsProvider
+      passwords:
+        solvahol.org.: env/MYTHIC_BEASTS_SECRET
   route53:
     class: octodns.provider.route53.Route53Provider
     access_key_id: env/AWS_ACCESS_KEY_ID
@@ -18,4 +22,5 @@ zones:
     sources:
       - config
     targets:
+      - mythicbeasts
       - route53


### PR DESCRIPTION
Adding Mythic Beasts so I can demonstrate using multiple providers. Mythic Beasts is one of few that support SSHFP, too, which I'm curious to learn how to use.

- - - - 
Add Mythic Beasts provider config
and :fingers-crossed: it'll work. Code asks for `password`, so I'm
unsure what creds to put. Surely it doesn't want my actual login
password. Right?

https://github.com/octodns/octodns/blob/a1ef4206682e10aa818b6fc4f02fa967a33700c2/octodns/provider/mythicbeasts.py#L61

